### PR TITLE
Extending PHPUnit test files.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -4,7 +4,7 @@ on:
   # push only for branches (ignore tags)
   push:
     branches:
-      - "main"
+      - "**"
     tags-ignore:
       - "**"
   # pull request only for branches (ignore tags)
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: plugin
 

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -21,13 +21,6 @@
  * @copyright  2023 Luca Bösch <luca.boesch@bfh.ch>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-/**
- * Test helper class for the uml question type.
- *
- * @copyright  2023 Luca Bösch <luca.boesch@bfh.ch>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
 class qtype_uml_test_helper extends question_test_helper {
 
     /**
@@ -50,11 +43,9 @@ class qtype_uml_test_helper extends question_test_helper {
         $q = new qtype_uml_question();
         test_question_maker::initialise_a_question($q);
         $q->qtype = question_bank::get_qtype('uml');
-        $q->contextid = context_system::instance()->id;
-        $q->penalty = 0.2; // The default.
-        test_question_maker::set_standard_combined_feedback_fields($q);
-        $q->graderinfo = '';
-        $q->graderinfoformat = FORMAT_HTML;
+        $q->name = 'UML Question';
+        $q->questiontext = 'Draw an UML diagram';
+        $q->generalfeedback = 'You should do this and that';
         return $q;
     }
 
@@ -67,5 +58,43 @@ class qtype_uml_test_helper extends question_test_helper {
     public static function make_uml_question_basic() {
         $q = self::make_a_uml_question();
         return $q;
+    }
+
+    /**
+     * Get the form data that corresponds to an uml question.
+     *
+     * @return stdClass simulated question form data.
+     */
+    public function get_uml_question_form_data_basic() {
+        $form = new stdClass();
+        $form->name = 'UML Question';
+        $form->questiontext = ['text' => 'Draw an UML diagram', 'format' => FORMAT_HTML];
+        $form->defaultmark = 1;
+        $form->generalfeedback = [
+            'text' => 'You should do this and that',
+            'format' => FORMAT_HTML,
+        ];
+
+        $form->qtype = 'uml';
+        return $form;
+    }
+
+    /**
+     * Get the raw data that corresponds to an uml question.
+     *
+     * @return stdClass simulated question form data.
+     */
+    public function get_uml_question_data_basic() {
+        $questiondata = new stdClass();
+        test_question_maker::initialise_question_data($questiondata);
+        $questiondata->qtype = 'uml';
+        $questiondata->name = 'UML Question';
+        $questiondata->questiontext = 'Draw an UML diagram';
+        $questiondata->generalfeedback = 'You should do this and that';
+
+        $questiondata->options = new stdClass();
+        test_question_maker::set_standard_combined_feedback_fields($questiondata->options);
+        $questiondata->options->showgrading = true;
+        return $questiondata;
     }
 }

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -20,6 +20,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
+require_once($CFG->dirroot . '/question/type/uml/question.php');
 require_once($CFG->dirroot . '/question/type/uml/tests/helper.php');
 
 /**
@@ -41,5 +42,87 @@ class question_test extends \advanced_testcase {
         $uml = new \qtype_uml_question();
         $uml->questiontext = 'UML';
         $this->assertEquals('UML', $uml->get_question_summary());
+    }
+
+    /**
+     * Test summarise response
+     *
+     * @covers ::summarise_response
+     * @return void
+     */
+    public function test_summarise_response(): void {
+        $longstring = str_repeat('0123456789', 50);
+        $uml = \test_question_maker::make_question('uml');
+        $this->assertEquals($longstring, $uml->summarise_response(
+            ['answer' => $longstring, 'answerformat' => FORMAT_HTML]));
+    }
+
+    /**
+     * Test is same response
+     *
+     * @covers ::is_same_response
+     * @return void
+     */
+    public function test_is_same_response(): void {
+        $uml = \test_question_maker::make_question('uml');
+
+        $uml->start_attempt(new \question_attempt_step(), 1);
+
+        $this->assertTrue($uml->is_same_response(
+            [],
+            ['answer' => '']));
+
+        $this->assertTrue($uml->is_same_response(
+            ['answer' => ''],
+            ['answer' => '']));
+
+        $this->assertTrue($uml->is_same_response(
+            ['answer' => ''],
+            []));
+
+        $this->assertFalse($uml->is_same_response(
+            ['answer' => 'Hello'],
+            []));
+
+        $this->assertFalse($uml->is_same_response(
+            ['answer' => 'Hello'],
+            ['answer' => '']));
+
+        $this->assertFalse($uml->is_same_response(
+            ['answer' => 0],
+            ['answer' => '']));
+
+        $this->assertFalse($uml->is_same_response(
+            ['answer' => ''],
+            ['answer' => 0]));
+
+        $this->assertFalse($uml->is_same_response(
+            ['answer' => '0'],
+            ['answer' => '']));
+
+        $this->assertFalse($uml->is_same_response(
+            ['answer' => ''],
+            ['answer' => '0']));
+    }
+
+    /**
+     *  Test is complete response
+     *
+     * @covers ::is_complete_response
+     * @return void
+     */
+    public function test_is_complete_response(): void {
+
+        $uml = \test_question_maker::make_question('uml');
+        $uml->start_attempt(new \question_attempt_step(), 1);
+
+        // The empty string should be considered an empty response, as should a lack of a response.
+        $this->assertFalse($uml->is_complete_response(['answer' => '']));
+        $this->assertFalse($uml->is_complete_response([]));
+
+        // Any nonempty string should be considered a complete response.
+        $this->assertTrue($uml->is_complete_response(['answer' => 'A student response.']));
+        $this->assertTrue($uml->is_complete_response(['answer' => '0 times.']));
+        $this->assertTrue($uml->is_complete_response(['answer' => '0']));
     }
 }

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -22,7 +22,8 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/question/type/uml/questiontype.php');
-
+require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
+require_once($CFG->dirroot . '/question/format/xml/format.php');
 
 /**
  * Unit tests for the uml question type class.
@@ -57,9 +58,9 @@ class questiontype_test extends \advanced_testcase {
     }
 
     /**
-     * Test get_name
+     * Test column name getter/setter
      *
-     * @covers ::get_name()
+     * @covers ::name()
      */
     public function test_name(): void {
         $this->assertEquals($this->qtype->name(), 'uml');
@@ -93,5 +94,124 @@ class questiontype_test extends \advanced_testcase {
         $q = $this->get_test_question_data();
         $this->assertEquals([], $this->qtype->get_possible_responses($q));
 
+    }
+
+    /**
+     * Method to assert that two xml strings are the same
+     *
+     * @param string $expectedxml the expected xml
+     * @param string $xml the xml to compare
+     * @return void
+     */
+    public function assert_same_xml($expectedxml, $xml) {
+        $this->assertEquals(str_replace("\r\n", "\n", $expectedxml),
+            str_replace("\r\n", "\n", $xml));
+    }
+
+    /**
+     * Test initialise question instance
+     *
+     * @covers \qtype_uml::make_question
+     * @return void
+     */
+    public function test_initialise_question_instance() {
+        $qdata = \test_question_maker::get_question_data('uml', 'basic');
+        $expectedq = \test_question_maker::make_question('uml', 'basic');
+        $qdata->stamp = $expectedq->stamp;
+        $qdata->version = $expectedq->version;
+        $qdata->timecreated = $expectedq->timecreated;
+        $qdata->timemodified = $expectedq->timemodified;
+
+        $question = $this->qtype->make_question($qdata);
+
+        $this->assertEquals($expectedq, $question);
+    }
+
+    /**
+     * Test xml import
+     *
+     * @covers \qtype_uml::import_from_xml
+     * @return void
+     * @throws \coding_exception
+     */
+    public function test_xml_import() {
+        $xml = '  <question type="uml">
+    <name>
+      <text>UML question</text>
+    </name>
+    <questiontext format="html">
+      <text>Draw an UML diagram</text>
+    </questiontext>
+    <generalfeedback>
+      <text>You should do this and that</text>
+    </generalfeedback>
+    <defaultgrade>6</defaultgrade>
+    <penalty>0.3333333</penalty>
+    <hidden>0</hidden>
+    <showstandardinstruction>0</showstandardinstruction>
+  </question>';
+        $xmldata = xmlize($xml);
+
+        $importer = new \qformat_xml();
+        $q = $importer->try_importing_using_qtypes(
+            $xmldata['question'], null, null, 'uml');
+
+        $expectedq = new \stdClass();
+        $expectedq->qtype = 'uml';
+        $expectedq->name = 'UML question';
+        $expectedq->questiontext = 'Draw an UML diagram';
+        $expectedq->questiontextformat = FORMAT_HTML;
+        $expectedq->generalfeedback = 'General feedback.';
+        $expectedq->generalfeedbackformat = FORMAT_HTML;
+        $expectedq->defaultmark = 6;
+        $expectedq->length = 1;
+        $expectedq->penalty = 0.3333333;
+
+        $this->assertEquals(new question_check_specified_fields_expectation($expectedq), $q);
+    }
+
+    /**
+     * Test xml export
+     *
+     * @covers \qtype_uml::export_to_xml
+     * @return void
+     */
+    public function test_xml_export() {
+        $qdata = \test_question_maker::get_question_data('uml', 'basic');
+        $qdata->defaultmark = 6;
+
+        $exporter = new \qformat_xml();
+        $xml = $exporter->writequestion($qdata);
+
+        $expectedxml = '<!-- question: 0  -->
+  <question type="uml">
+    <name>
+      <text>UML question</text>
+    </name>
+    <questiontext format="html">
+      <text>Draw an UML diagram</text>
+    </questiontext>
+    <generalfeedback format="html">
+      <text>You should do this and that</text>
+    </generalfeedback>
+    <defaultgrade>6</defaultgrade>
+    <penalty>0.3333333</penalty>
+    <hidden>0</hidden>
+    <idnumber></idnumber>
+    <showstandardinstruction>0</showstandardinstruction>
+    <hint format="html">
+      <text>Hint 1.</text>
+      <shownumcorrect/>
+    </hint>
+    <hint format="html">
+      <text>Hint 2.</text>
+      <shownumcorrect/>
+      <clearwrong/>
+      <options>1</options>
+    </hint>
+  </question>
+';
+
+        $this->assert_same_xml($expectedxml, $xml);
     }
 }


### PR DESCRIPTION
Hi @arisjavet-personal and @bschur.
I think you really need to include tests now. Those make sure the question is able to be used in quizzes, the score works, as well as backup and restore do function.
Until those functions are not be implemented, this plugin would not be able to be included in no Moodle installation, and even less included in the Moodle Plugins database https://moodle.org/plugins.