### PR TITLE
Prepare for Moodle 4.4

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -43,6 +43,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php: 8.3
+            moodle-branch: MOODLE_404_STABLE
+            database: pgsql
+          - php: 8.3
+            moodle-branch: MOODLE_404_STABLE
+            database: mariadb
+
+          - php: 8.2
+            moodle-branch: MOODLE_404_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_404_STABLE
+            database: mariadb
           - php: 8.2
             moodle-branch: MOODLE_403_STABLE
             database: pgsql
@@ -56,6 +69,12 @@ jobs:
             moodle-branch: MOODLE_402_STABLE
             database: mariadb
 
+          - php: 8.1
+            moodle-branch: MOODLE_404_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_404_STABLE
+            database: mariadb
           - php: 8.1
             moodle-branch: MOODLE_403_STABLE
             database: pgsql
@@ -135,11 +154,6 @@ jobs:
       - name: PHP Lint
         if: ${{ always() }}
         run: moodle-plugin-ci phplint
-
-      - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpcpd
 
       - name: PHP Mess Detector
         continue-on-error: true # This step will show errors but will not fail

--- a/lang/en/qtype_uml.php
+++ b/lang/en/qtype_uml.php
@@ -25,6 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+$string['correctanswer'] = 'Correct solution';
 $string['pluginname'] = 'Moodle UML (BFH)';
 $string['pluginname_help'] = 'UML questions consist of interactive editor where responders can design their diagram.';
 $string['pluginname_link'] = 'question/type/uml';
@@ -32,6 +33,5 @@ $string['pluginnameadding'] = 'Adding a UML question';
 $string['pluginnameediting'] = 'Editing a UML question';
 $string['pluginnamesummary'] = 'UML questions consist of interactive editor where responders can design their diagram.';
 $string['privacy:metadata'] = 'The UML question type plugin does not store any personal data.';
-$string['correctanswer'] = 'Correct solution';
 $string['suggested_comment'] = 'Suggested comment';
 $string['suggested_points'] = 'Suggested points';

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -30,7 +30,7 @@ require_once($CFG->dirroot . '/question/type/uml/tests/helper.php');
  * @copyright  2023 Luca Bösch <luca.boesch@bfh.ch>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class question_test extends \advanced_testcase {
+final class question_test extends \advanced_testcase {
 
     /**
      * Test get_question_summary

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/question/format/xml/format.php');
  * @copyright  2023 Luca Bösch <luca.boesch@bfh.ch>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class questiontype_test extends \advanced_testcase {
+final class questiontype_test extends \advanced_testcase {
 
     /** @var uml instance of the question type class to test. */
     protected $qtype;
@@ -114,7 +114,7 @@ class questiontype_test extends \advanced_testcase {
      * @covers \qtype_uml::make_question
      * @return void
      */
-    public function test_initialise_question_instance() {
+    public function test_initialise_question_instance(): void {
         $qdata = \test_question_maker::get_question_data('uml', 'basic');
         $expectedq = \test_question_maker::make_question('uml', 'basic');
         $qdata->stamp = $expectedq->stamp;
@@ -134,7 +134,7 @@ class questiontype_test extends \advanced_testcase {
      * @return void
      * @throws \coding_exception
      */
-    public function test_xml_import() {
+    public function test_xml_import(): void {
         $xml = '  <question type="uml">
     <name>
       <text>UML question</text>
@@ -176,7 +176,7 @@ class questiontype_test extends \advanced_testcase {
      * @covers \qtype_uml::export_to_xml
      * @return void
      */
-    public function test_xml_export() {
+    public function test_xml_export(): void {
         $qdata = \test_question_maker::get_question_data('uml', 'basic');
         $qdata->defaultmark = 6;
 

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -32,7 +32,7 @@ require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
  * @copyright  2023 Luca Bösch <luca.boesch@bfh.ch>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class walkthrough_test extends \qbehaviour_walkthrough_test_base {
+final class walkthrough_test extends \qbehaviour_walkthrough_test_base {
 
     /**
      * Test feedback with deferredfeedback question behaviour


### PR DESCRIPTION
You can begin to check for Moodle 4.4 as well which was released on April 22nd.
It supports PHP 8.3 and has to be checked against.